### PR TITLE
Fix Spotify track list hover effect

### DIFF
--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -278,7 +278,8 @@ span.h3IntroSpan.emoji {
   transition: background-color 0.15s ease;
 
   &:hover {
-    background-color: rgba(0, 0, 0, 0.1);
+    transform: none;
+    background-color: rgba(0, 0, 0, 0.08);
   }
 }
 


### PR DESCRIPTION
## Summary
- Override global a:hover scale transform on Spotify track list items
- Use subtle background highlight instead of growing the element

https://claude.ai/code/session_019Xz9pXVHoSFQt8ZYQBM2ZF